### PR TITLE
Fix google api key ENV name.

### DIFF
--- a/app/services/learning_resources_service.rb
+++ b/app/services/learning_resources_service.rb
@@ -6,7 +6,7 @@ class LearningResourcesService
 
   def self.conn_video
     Faraday.new("https://youtube.googleapis.com/youtube") do |f|
-      f.params['key'] = ENV['GOOGLE_API-KEY']
+      f.params['key'] = ENV['GOOGLE_API_KEY']
     end
   end 
 

--- a/spec/facades/learning_resource_facade_spec.rb
+++ b/spec/facades/learning_resource_facade_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe LearningResourceFacade do
     header = {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Faraday v2.7.3'}
 
     stub_request(:get, "https://youtube.googleapis.com/v3/search?channelId=UCluQ5yInbeAkkeCndNnUhpw&fields=items(id,snippet(title))&maxResults=1&part=snippet&q=Egypt&type=video")
-    .with(headers: header, query: {"key" => ENV['GOOGLE_API-KEY']})
+    .with(headers: header, query: {"key" => ENV['GOOGLE_API_KEY']})
     .to_return(status: 200, body: json_response, headers: {})
 
     pexel_response = File.read('spec/fixtures/egypt_pexel.json')

--- a/spec/requests/api/v1/get_learning_resources_spec.rb
+++ b/spec/requests/api/v1/get_learning_resources_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Get LearningResources', :type => :request do
     header = {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Faraday v2.7.3'}
 
     stub_request(:get, "https://youtube.googleapis.com/v3/search?channelId=UCluQ5yInbeAkkeCndNnUhpw&fields=items(id,snippet(title))&maxResults=1&part=snippet&q=Egypt&type=video")
-    .with(headers: header, query: {"key" => ENV['GOOGLE_API-KEY']})
+    .with(headers: header, query: {"key" => ENV['GOOGLE_API_KEY']})
     .to_return(status: 200, body: json_response, headers: {})
 
     pexel_response = File.read('spec/fixtures/egypt_pexel.json')

--- a/spec/services/learning_resources_service_spec.rb
+++ b/spec/services/learning_resources_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe LearningResourcesService do
       header = {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Faraday v2.7.3'}
 
       stub_request(:get, "https://youtube.googleapis.com/v3/search?channelId=UCluQ5yInbeAkkeCndNnUhpw&fields=items(id,snippet(title))&maxResults=1&part=snippet&q=Egypt&type=video")
-      .with(headers: header, query: {"key" => ENV['GOOGLE_API-KEY']})
+      .with(headers: header, query: {"key" => ENV['GOOGLE_API_KEY']})
       .to_return(status: 200, body: json_response, headers: {})
 
       response = LearningResourcesService.get_video("Egypt")


### PR DESCRIPTION
Fix: rename google api key from "GOOGLE_API-KEY" to "GOOGLE_API_KEY"